### PR TITLE
Render with children

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,25 +56,30 @@ The decision trees of which component or function to call is done in the followi
 
 - Is the flag truthy?
   - Yes
-    - Did the developer declare a `component` prop?
+    - Does the component have a child(ren)?
       - Yes
-        - Render an instance of that component
+        - Render the child(ren)
         - DONE.
       - No
-        - Did the developer declare a `render` prop?
+        - Does the component have a `component` prop?
           - Yes
-            - Call the function and use the return.
+            - Render an instance of that component
             - DONE.
           - No
-            - Render `null`
-            - DONE.
+            - Does the component have a `render` prop?
+              - Yes
+                - Call the function and use the return.
+                - DONE.
+              - No
+                - Render `null`
+                - DONE.
   - No
-    - Did the developer declare a `fallbackComponent` prop?
+    - Does the component have a `fallbackComponent` prop?
       - Yes
         - Render an instance of that component
         - DONE.
       - No
-        - Did the developer declare a `fallbackRender` prop?
+        - Does the component have a `fallbackRender` prop?
           - Yes
             - Call the function and use the return.
             - DONE.
@@ -109,6 +114,18 @@ import { Flag } from 'flag';
   fallbackComponent={ExistingFeature}
 />
 ```
+
+If you don't care about the fallback case - render nothing if false - then you can also render your component inline as children.
+
+
+```jsx
+import { Flag } from 'flag';
+
+<Flag name="features.useMyCoolNewThing">
+  <RevisedFeature />
+</Flag>
+```
+
 
 ### Use with `react`
 
@@ -211,6 +228,7 @@ The main React component.
 Prop | Type | Required | Description
 --- | --- | --- | ---
 name | string | true | The name of the feature to check
+children | React.ReactElement<any> | false | The rendered result if the flag is __truthy__
 render | (val: any) => ReactElement | false | The render function if the flag is __truthy__
 fallbackRender | (val: any) => ReactElement | false | The render function if the flag is __falsy__
 component | React.ComponentType<any> | false | The component to use if the flag is __truthy__

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "jest",
     "build": "rm -rf build && tsc --outDir build -d",
+    "prepublish": "build",
     "release": "np"
   },
   "dependencies": {

--- a/src/flag.tsx
+++ b/src/flag.tsx
@@ -48,15 +48,21 @@ export class Flag extends React.Component<FlagProps, {}> {
   public render() {
     const { name, component, render, fallbackComponent, fallbackRender, ...rest } = this.props;
     const value = getFlag(this.context[key], name);
+    const isEnabled = Boolean(value);
+
     const props: FlagChildProps<typeof rest, { [key: string]: typeof value }> = {
       ...rest,
       flags: { [name]: value },
     };
 
-    if (Boolean(value)) {
-      return resolve(props, component, render) || null;
-    } else {
-      return resolve(props, fallbackComponent, fallbackRender) || null;
+    if (isEnabled && props.children) {
+      return props.children;
     }
+
+    if (isEnabled) {
+      return resolve(props, component, render) || null;
+    }
+
+    return resolve(props, fallbackComponent, fallbackRender) || null;
   }
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -216,6 +216,69 @@ describe('FlagsProvider && Flag', () => {
       </FlagsProvider>,
     );
   });
+
+  it('can render children if they are provided present and flag is truthy', () => {
+    expect.assertions(4);
+
+    const flags: Flags = {
+      a: 500,
+    };
+
+    function MyComponent() {
+      expect(true).toEqual(true);
+      return null;
+    }
+
+    mount(
+      <FlagsProvider flags={flags}>
+        <div>
+          <Flag name="a">
+            <MyComponent />
+          </Flag>
+          <Flag name="a">
+            <MyComponent />
+          </Flag>
+          <Flag name="a">
+            <MyComponent />
+          </Flag>
+          <Flag name="a">
+            <MyComponent />
+          </Flag>
+        </div>
+      </FlagsProvider>,
+    );
+  });
+
+  it('can render nothing if children are provided but flags are falsy', () => {
+    expect.assertions(1);
+
+    const flags: Flags = {
+      a: false,
+      b: true,
+      c: '',
+    };
+
+    function MyComponent() {
+      expect(true).toEqual(true);
+      return null;
+    }
+
+    mount(
+      <FlagsProvider flags={flags}>
+        <div>
+          <Flag name="a">
+            <MyComponent />
+          </Flag>
+          <Flag name="b">
+            <MyComponent />
+          </Flag>
+          <Flag name="c">
+            <MyComponent />
+          </Flag>
+        </div>
+      </FlagsProvider>,
+    );
+  });
 });
 
 describe('ConnectedFlagsProvider && Flag', () => {
@@ -233,10 +296,12 @@ describe('ConnectedFlagsProvider && Flag', () => {
     }
 
     interface State {
+      hello: boolean;
       flags: Resolved;
     }
 
     const reducer = combineReducers<State>({
+      hello: (state = true) => state,
       flags: createFlagsReducer({
         a: true,
         b: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,6 @@ export interface ResolvedFlags {
   [key: string]: ResolvedValue;
 }
 
-export type FlagChildProps<P, F = ResolvedFlags> = P & { flags: F };
+export type FlagChildProps<P, F = ResolvedFlags> = P & { flags: F; children?: any };
 
 export type Renderer = (props: FlagChildProps<any>) => React.ReactNode;


### PR DESCRIPTION
Allows you to say

```jsx
<Flag name="featureName">
  <MyComponent />
</Flag>
```

instead of

```jsx
<Flag name="featureName" component={MyComponent} />
```

if you want