### PR TITLE
Resolving undefined nested flags as false

### DIFF
--- a/src/flag.tsx
+++ b/src/flag.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { key } from './key';
 import { Flags, FlagChildProps, Value, Renderer } from './types';
 
+const get = require('lodash/get')
 export interface FlagProps {
   name: string;
   component?: React.ComponentType<FlagChildProps<any>>;
@@ -12,18 +13,7 @@ export interface FlagProps {
 }
 
 function getFlag(flags: Flags, keyPath: string): Value | void {
-  const [head, ...tail] = keyPath.split('.');
-  let result: Value = (flags as Flags)[head];
-
-  for (const key of tail) {
-    result = (result as Flags)[key];
-
-    if (result === undefined || result === null) {
-      return false;
-    }
-  }
-
-  return result;
+  return get(flags, keyPath, false);
 }
 
 function resolve(

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -279,6 +279,46 @@ describe('FlagsProvider && Flag', () => {
       </FlagsProvider>,
     );
   });
+
+  it('can render nothing if nested flags don\'t exist', () => {
+    expect.assertions(1);
+
+    const flags: Flags = {
+      a: {
+        someProp: {
+          flag: true
+        }
+      },
+      b: {
+        someProp: true
+      },
+      c: true,
+    };
+
+    function MyComponent() {
+      expect(true).toEqual(true);
+      return null;
+    }
+
+    mount(
+      <FlagsProvider flags={flags}>
+        <div>
+          <Flag name="a.someProp.flag">
+            <MyComponent />
+          </Flag>
+          <Flag name="b.someProp.flag">
+            <MyComponent />
+          </Flag>
+          <Flag name="c.someProp.flag">
+            <MyComponent />
+          </Flag>
+          <Flag name="d.someProp.flag">
+            <MyComponent />
+          </Flag>
+        </div>
+      </FlagsProvider>,
+    );
+  });
 });
 
 describe('ConnectedFlagsProvider && Flag', () => {


### PR DESCRIPTION
Previous solution threw a `TypeError` if a top-level property in `some.nested.flag` hadn't been defined.