### PR TITLE
FlagsProvider always renders children

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@types/react-dom": "^16.8.3",
     "@types/react-redux": "^7.0.7",
     "@types/redux": "^3.6.0",
-    "@types/shallowequal": "^1.1.1",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "jest": "^24.7.1",
@@ -29,7 +28,6 @@
   "dependencies": {
     "deep-computed": "^0.1.2",
     "lodash": "^4.17.11",
-    "shallowequal": "^1.1.0",
     "useful-types": "^0.2.1"
   },
   "peerDependencies": {

--- a/src/create-flags.tsx
+++ b/src/create-flags.tsx
@@ -1,5 +1,4 @@
-import React, { useContext } from "react";
-import shallowEqual from "shallowequal";
+import React, { useContext, useMemo } from "react";
 import { deepComputed, Computable } from "deep-computed";
 import { KeyPath, KeyPathValue } from "useful-types";
 import { isObject } from "./utils";
@@ -42,17 +41,11 @@ export function createFlags<T>(): CreateFlags<T> {
   const Context = React.createContext<T | null>(null) as React.Context<T>;
   Context.displayName = "Flag";
 
-  class FlagsProvider extends React.Component<ProviderProps<T>> {
-    shouldComponentUpdate(prevProps: ProviderProps<T>) {
-      return !shallowEqual(this.props.flags, prevProps.flags);
-    }
-
-    render() {
-      const value = deepComputed(this.props.flags);
-      return (
-        <Context.Provider value={value}>{this.props.children}</Context.Provider>
-      );
-    }
+  const FlagsProvider: React.SFC<ProviderProps<T>> = ({ flags, children }) => {
+    const value = useMemo(() => deepComputed(flags), [flags])
+    return (
+      <Context.Provider value={value}>{children}</Context.Provider>
+    );
   }
 
   const useFlags = () => useContext(Context);

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,10 +382,6 @@
   dependencies:
     redux "*"
 
-"@types/shallowequal@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/shallowequal/-/shallowequal-1.1.1.tgz#aad262bb3f2b1257d94c71d545268d592575c9b1"
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -3943,10 +3939,6 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Removed not rendering FlagsProvider when the flags don't change. This caused the children not to be rendered either, preventing use of the FlagsProvider in components with children that need to respond to state changes.

Basically I don't want to make another wrapper component just for the FlagsProvider, and it seemed like an unnecessary restriction. The `deepComputed` value will only be calculated when `flags` changes, and the children can do their own optimization and choose whether or not to be rendered.