### PR TITLE
Moved optional depenencies to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@types/react": "^16.8.12",
     "@types/react-dom": "^16.8.3",
     "@types/react-redux": "^7.0.7",
-    "@types/redux": "^3.6.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "jest": "^24.7.1",
@@ -31,16 +30,12 @@
     "useful-types": "^0.2.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
-  },
-  "optionalDependencies": {
-    "@types/react": "^16.8.12",
-    "@types/react-dom": "^16.8.3",
-    "@types/react-redux": "^7.0.7",
-    "@types/redux": "^3.6.0",
-    "react-redux": "^7.0.2",
-    "redux": "^4.0.1"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
+    "react-redux": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "redux": "^4.0.0",
+    "@types/react": "^16.8.0",
+    "@types/react-dom": "^16.8.0"
   },
   "scripts": {
     "clean": "rm -rf build",


### PR DESCRIPTION
This PR moves the optional dependencies to peer dependencies, which are for instances where the library needs to consume the exact same instance of the dependency the main application depends on. That is important here.

Justifications for each change:
* @types/redux is not necessary, redux provides its own types
* redux is a peer dep, we need to have at least 4.x for correct type info, we want to use the implementer's existing version.
* react/react-dom need to have hooks, so ^16.8
* react-redux will be okay with a pretty wide range of versions. >5.x seems safe
* @types/react and @types/react-dom can be in peer dependencies. We do want these to be the same version used by the implementing application.