### PR TITLE
Handle missing context gracefully

### DIFF
--- a/src/create-flags.test.tsx
+++ b/src/create-flags.test.tsx
@@ -209,4 +209,20 @@ describe("useFlag/useFlags", () => {
       </FlagsProvider>
     );
   });
+
+  it("handles missing context gracefully", () => {
+    expect.assertions(2);
+
+    const MyComponent = () => {
+      const flagA = useFlag(["a"]);
+      const next = useFlags();
+
+      expect(flagA).toBeUndefined();
+      expect(next).toBeNull();
+
+      return null;
+    };
+
+    mount(<MyComponent />);
+  });
 });

--- a/src/create-flags.tsx
+++ b/src/create-flags.tsx
@@ -48,10 +48,23 @@ export function createFlags<T>(): CreateFlags<T> {
     );
   }
 
-  const useFlags = () => useContext(Context);
+  const useFlags = () => {
+    const value = useContext(Context);
+    if (value == null) {
+      console.warn('<Flag /> is expected to have a <FlagsProvider /> ancestor')
+    }
+
+    return value;
+  }
 
   const useFlag = <KP extends KeyPath<T>>(keyPath: KP): KeyPathValue<T, KP> => {
     const flags = useFlags();
+
+    // handle the case in which there is no context from a FlagsProvider
+    if (flags == null) {
+      return undefined as any;
+    }
+
     let result: any = flags;
 
     for (let next of keyPath as string[]) {


### PR DESCRIPTION
Makes the `<Flag />` component handle a missing `<FlagsProvider />` ancestor gracefully. The component will log a warning and default to acting as if the given flag is disabled.

I believe this change should align well with the libraries current behaviors about invalid flag names. Let me know any thoughts!

